### PR TITLE
Improve title

### DIFF
--- a/_layouts/vimdoc.html
+++ b/_layouts/vimdoc.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="UTF-8">
-<title>Vim: {{ page.helpname }}.txt</title>
+<title>Vim: {{ page.helpname }}</title>
 <meta name="Generator" content="Vim/7.4">
 <meta name="plugin-version" content="vim7.4_v1">
 <meta name="syntax" content="help">
@@ -34,7 +34,7 @@
   <a href="http://vim-jp.org/">vim-jp</a>
   / <a href="http://vim-jp.org/vimdoc-ja/">vimdoc-ja</a>
   / {{ page.helpname }}<br />
-  <a name="top"></a><h1>Vim documentation: {{ page.helpname }}.txt</h1>
+  <a name="top"></a><h1>Vim documentation: {{ page.helpname }}</h1>
   <a href="index.html">main help file</a>
 </div>
 </header>

--- a/_layouts/vimdoc.html
+++ b/_layouts/vimdoc.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta charset="UTF-8">
-<title>Vim documentation: {{ page.helpname }}</title>
+<title>Vim: {{ page.helpname }}.txt</title>
 <meta name="Generator" content="Vim/7.4">
 <meta name="plugin-version" content="vim7.4_v1">
 <meta name="syntax" content="help">
@@ -34,7 +34,7 @@
   <a href="http://vim-jp.org/">vim-jp</a>
   / <a href="http://vim-jp.org/vimdoc-ja/">vimdoc-ja</a>
   / {{ page.helpname }}<br />
-  <a name="top"></a><h1>Vim documentation: {{ page.helpname }}</h1>
+  <a name="top"></a><h1>Vim documentation: {{ page.helpname }}.txt</h1>
   <a href="index.html">main help file</a>
 </div>
 </header>


### PR DESCRIPTION
>http://anond.hatelabo.jp/20160228104001
Vim documentation: options
documentationが長くてタブにoptionのoの字も表示されなくて見づらい
長いサイトタイトルを左に持ってくるのって普通なんだろうか
本家はVim: options.txtと表記されており分かりやすい

appspotの新しい方ではそうなっているみたいですね
http://vimhelp.appspot.com/

ファイル名とサイトタイトルを入れ替えるのもあり？