### PR TITLE
英語/日本語切り替えリンクの追加

### DIFF
--- a/_layouts/vimdoc.html
+++ b/_layouts/vimdoc.html
@@ -39,6 +39,11 @@
   / {{ page.helpname }}<br />
   <a name="top"></a><h1>{{ page.helpname }} - Vim日本語ドキュメント</h1>
   <a href="index.html">メインヘルプファイルに戻る</a>
+
+  <span class="EnglishJapaneseLink">
+    <a href="http://vim-jp.org/vimdoc-en{{ page.url }}">English</a>
+    | <span class="CurrentLanguage">Japanese</span>
+  </span>
 </div>
 </header>
 
@@ -255,7 +260,12 @@
 </article>
 
 <footer>
-<a href="#top">トップに戻る</a> - <a href="index.html">メインヘルプファイルに戻る</a><br>
+<a href="#top">トップに戻る</a> - <a href="index.html">メインヘルプファイルに戻る</a>
+<span class="EnglishJapaneseLink">
+  <a href="http://vim-jp.org/vimdoc-en{{ page.url }}">English</a>
+  | <span class="CurrentLanguage">Japanese</span>
+</span>
+<br />
 <div style="text-align:right;">
 Translated by <a href="https://github.com/vim-jp/vimdoc-ja">vimdoc-ja プロジェクト</a><br />
 ヘルプ一式ダウンロード: <a href="https://github.com/vim-jp/vimdoc-ja/archive/master.tar.gz">tar.gz</a> | <a href="https://github.com/vim-jp/vimdoc-ja/archive/master.zip">zip</a><br />

--- a/style.css
+++ b/style.css
@@ -155,4 +155,8 @@ a.EnglishPage:hover {
     color: white;
 }
 
+.EnglishJapaneseLink {
+    float: right;
+}
+
 /* vim:set ts=8 sts=4 sw=4 tw=0 et: */


### PR DESCRIPTION
See: vim-jp/vimdoc-ja-working#120

ページの上下に、vimdoc-enとの切り替えように「English | Japanese」と出すようにしてみました。
デザインは仮。