### PR TITLE
Don't highlight "MissingTag"

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,8 +4,10 @@
     border:0;
 }
 .MissingTag {
+    /*
     background-color: black;
     color: white;
+    */
 }
 .EnglishTag {
     background-color: gray;


### PR DESCRIPTION
現在、リンク先が見つからない項目は、黒地に白色で表示されていますが、リンク先がないことを強調する利点は特にないのではないかと思います。(せいぜい、オプション名のtypoに気づきやすくなるくらいでしょう。)

不必要にシングルクォーテーションを使用していた部分も既に修正済みですので、まだMissingTagが残っている部分はリンクする必要がない部分のはずです。
通常表示にしてしまってよいのではないでしょうか。