### PR TITLE
terminal へのリンクを追加

### DIFF
--- a/_layouts/vimdoc.html
+++ b/_layouts/vimdoc.html
@@ -178,6 +178,7 @@
 <li><a href="ft_sql.html">ft_sql</a></li>
 <li><a href="hangulin.html">hangulin</a></li>
 <li><a href="rileft.html">rileft</a></li>
+<li><a href="terminal.html">terminal</a></li>
 </ul></dd>
 
 <dt>GUI</dt>


### PR DESCRIPTION
原文には無いので、追加された際には要修正。
see also https://github.com/vim-jp/vimdoc-ja/issues/240

https://github.com/vim-jp/vimdoc-ja-working/pull/184 をマージしたあとに
こちらをマージすることで
http://vim-jp.org/vimdoc-ja/terminal.html
へのリンクが左側のメニューに表示されるという寸法です。