### PR TITLE
Fix use octicon pencil for icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /_site/
 /target/
 /tmp/
+Gemfile.lock

--- a/_config.yml
+++ b/_config.yml
@@ -24,5 +24,6 @@ kramdown:
 # baseurl と紛らわしいが別物なので要注意
 base-url:    http://vim-jp.org/vimdoc-ja
 
-gems:
+plugins:
   - jekyll-redirect-from
+  - jekyll-octicons

--- a/_layouts/vimdoc.html
+++ b/_layouts/vimdoc.html
@@ -44,7 +44,7 @@
     <a href="http://vim-jp.org/vimdoc-en{{ page.url }}">English</a>
     | <span class="CurrentLanguage">日本語</span>
     {% if page.helpname != 'tags' %}
-    | <a href="https://github.com/vim-jp/vimdoc-ja-working/blob/master/doc/{{ page.helpname | replace:'vimindex','index' }}.jax">📝編集</a>
+    | <a href="https://github.com/vim-jp/vimdoc-ja-working/blob/master/doc/{{ page.helpname | replace:'vimindex','index' }}.jax">{% octicon pencil %} 編集</a>
     {% endif %}
   </span>
 </div>
@@ -270,7 +270,7 @@
   <a href="http://vim-jp.org/vimdoc-en{{ page.url }}">English</a>
   | <span class="CurrentLanguage">日本語</span>
   {% if page.helpname != 'tags' %}
-  | <a href="https://github.com/vim-jp/vimdoc-ja-working/blob/master/doc/{{ page.helpname | replace:'vimindex','index' }}.jax">📝編集</a>
+  | <a href="https://github.com/vim-jp/vimdoc-ja-working/blob/master/doc/{{ page.helpname | replace:'vimindex','index' }}.jax">{% octicon pencil %} 編集</a>
   {% endif %}
 </span>
 <br />
@@ -279,6 +279,7 @@ Translated by <a href="https://github.com/vim-jp/vimdoc-ja">vimdoc-ja プロジ�
 ヘルプ一式ダウンロード: <a href="https://github.com/vim-jp/vimdoc-ja/archive/master.tar.gz">tar.gz</a> | <a href="https://github.com/vim-jp/vimdoc-ja/archive/master.zip">zip</a><br />
 間違いを見つけたら<a href="http://groups.google.com/group/vimdoc-ja">メーリングリスト</a>か<a href="https://github.com/vim-jp/vimdoc-ja-working/issues">issueトラッカー</a>でお知らせください。<br />
 <a href="https://github.com/vim-jp/vimdoc-ja-working/wiki/HowToContribute">参加者募集中。</a><br />
+<a href="https://raw.githubusercontent.com/primer/octicons/master/LICENSE">Powered by octicons</a><br /
 </div>
 </footer>
 


### PR DESCRIPTION
Closes #243

- Add Gemfile for use `octicon pencil`.
- Add license link
- Fix `Deprecation` warnings

Top
<img width="452" alt="2018-06-14 22 52 38" src="https://user-images.githubusercontent.com/56591/41417161-84f9f564-7027-11e8-990d-4df4d1c963e9.png">

Footer
<img width="347" alt="2018-06-14 22 52 44" src="https://user-images.githubusercontent.com/56591/41417177-8d729d18-7027-11e8-87b0-c6c93b28aea7.png">
