### PR TITLE
Dark Theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -161,4 +161,193 @@ a.EnglishPage:hover {
     float: right;
 }
 
+/*
+ * This dark theme is based on onedark.vim, which is licensed under MIT License.
+ * https://github.com/joshdick/onedark.vim
+ */
+@media (prefers-color-scheme: dark) {
+    * {
+        padding:0;
+        margin:0;
+        border:0;
+    }
+    .MissingTag {
+        /*
+        background-color: black;
+        color: white;
+        */
+    }
+    .EnglishTag {
+        background-color: gray;
+        color: white;
+    }
+
+    div#SearchForm {
+        float: right;
+        width: 200px;
+    }
+
+    div#SearchForm > div {
+        background: #282C34;
+        border-color: #54575c;
+    }
+
+    body {
+        background: #282C34;
+        color: #ABB2BF;
+        font-family: Verdana, sans-serif;
+        width: 800px;
+        margin: 16px auto;
+        padding: 24px;
+    }
+
+    h1, h2, h3 {
+        margin: 1em;
+    }
+    .Todo {
+        color: #0000ff;
+        background-color: #E5C07B;
+    }
+    .Ignore {
+        color: #282C34;
+    }
+    .PreProc {
+        color: #e5c07b;
+    }
+    .Special {
+        color: #61AFEF;
+    }
+    .Identifier {
+        color: #E06C75;
+    }
+    .Comment {
+        color: #C678DD;
+    }
+    .helpExample {
+        color: #C678DD;
+    }
+
+    header {
+        padding-bottom: 8px;
+        border-bottom: 1px solid #54575c;
+    }
+
+    nav {
+        float: left;
+        width: 132px;
+        font-size: 9pt;
+        padding: 8px 0px;
+        border-right: 1px solid #cad2e0;
+    }
+
+    nav li {
+        margin-bottom: 1px;
+        list-style-type: none;
+    }
+
+    nav li a {
+        display: block;
+        text-decoration: none;
+        padding: 0.2em 1em;
+    }
+
+    nav dt {
+        margin: 0.8em 0 1px;
+        border-top: 1px solid #c3c3c3;
+        border-left: 4px solid #56B6C2;
+        padding: 1px 0 1px 4px;
+        color: #56B6C2;
+    }
+
+    nav li a:link,
+    nav li a:visited {
+        color: #61AFEF;
+    }
+
+    nav li a:active,
+    nav li a:hover {
+        background-color: #E06C75;
+        color: #282C34;
+    }
+
+    nav li a.CurrentPage {
+        background-color: #61AFEF;
+        color: #282C34;
+    }
+
+    article.Vimdoc {
+        float: left;
+        width: 600px;
+        display: block;
+        padding: 1em 2em;
+        border-left: 1px solid #54575c;
+        position: relative;
+        left: -1px;
+        font-family: monospace, "Osaka-mono", "Osaka-等幅", "ＭＳ ゴシック", "Courier New";
+        font-size: 10.5pt;
+        line-height: 1.2em;
+        white-space: nowrap;
+    }
+
+    article.Vimdoc a:link,
+    article.Vimdoc a:visited,
+    article.Vimdoc a:active {
+    }
+
+    article.Vimdoc a:hover {
+        background-color: #E06C75;
+        color: #282C34;
+    }
+
+    article.Vimdoc a.Constant {
+        color: #98C379;
+    }
+
+    article.Vimdoc a.Constant:hover {
+        background-color: #98C379;
+        color: #282C34;
+    }
+
+    footer {
+        padding-top: 8px;
+        border-top: 1px solid #54575c;
+        clear: both;
+    }
+
+    /* Untranslated pages in TOC */
+    a.EnglishPage:link,
+    a.EnglishPage:visited,
+    a.EnglishPage:active {
+        color: gray;
+    }
+    a.EnglishPage:hover {
+        background-color: gray;
+        color: white;
+    }
+
+    /* Tag links to untranslate pages */
+    .ExternalTaglink {
+        background-color: gray;
+        color: white;
+    }
+
+    .EnglishJapaneseLink {
+        float: right;
+    }
+
+    /* Overwrite default css */
+    a {
+        color: #52a1ff;
+    }
+
+    a:visited {
+        color: #9e6ecf;
+    }
+
+    /* Pencil "edit" icon */
+    .octicon path {
+        fill: #ABB2BF;
+    }
+}
+
 /* vim:set ts=8 sts=4 sw=4 tw=0 et: */


### PR DESCRIPTION
ユーザーのシステム設定がダークモード優先になっている場合に、 vimdoc をダークモードで表示します。
以下のサンプルは Mac + Chrome で表示した例です。

![image](https://user-images.githubusercontent.com/47710717/93844487-43de5080-fcd8-11ea-89d0-1a6ed2dc6173.png)
![image](https://user-images.githubusercontent.com/47710717/93844511-56588a00-fcd8-11ea-9225-402e39eddf77.png)

(Done is better than perfect の精神で PR 出してみますがなにか改善案等ありましたら遠慮なくおっしゃっていただけると助かります)