### PR TITLE
Use LF for doc/tags-ja

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+doc/tags-ja	text eol=lf


### PR DESCRIPTION
`.gitattributes` を追加することで、常に（特に Windows で `core.autocrlf=true` になっている環境でも）LF 改行で doc/tags-ja をチェックアウトするようにします。

`:helptags` コマンドは Windows 版の Vim においても、常に LF 改行で tags ファイルを出力します。そのため、CRLF 改行で tags ファイルがチェックアウトされていると、`:helptags` で tags ファイルを更新したときに必ず差分が出てしまいます。
LF 改行でチェックアウトすることで、余計な差分が出なくなります。

関連: vim-jp/vimdoc-ja-working#268, #21

----

**`:helptags` コマンドの実装について**

`:helptags` で tags ファイルを作成する際は `fopen()` に `w` フラグを指定しているので、一見テキストモードで開いているように見える。
https://github.com/vim/vim/blob/e2982d691186c8a9b16ecc8d831d2472088c8ed8/src/help.c#L995

しかし、Windows 版 Vim では起動時に、ファイルはバイナリモードで開くように設定を変更している。
https://github.com/vim/vim/blob/e2982d691186c8a9b16ecc8d831d2472088c8ed8/src/os_win32.c#L2349
https://github.com/vim/vim/blob/e2982d691186c8a9b16ecc8d831d2472088c8ed8/src/os_win32.c#L2818

これにより、Windows 版 Vim でも tags ファイルは必ず LF 改行で作成される。