### PR TITLE
feat: Add ja special helpHeadline region

### DIFF
--- a/syntax/help_ja.vim
+++ b/syntax/help_ja.vim
@@ -13,5 +13,5 @@ if has("conceal")
 else
   syn region helpHeadlineQuote matchgroup=helpIgnore start="^=" end="=$" contains=helpHeadlineValue keepend
 endif
-syn match  helpHeadlineValue "[^=].\+[^=]" contained
+syn match  helpHeadlineValue "[^=].*[^=]" contained
 hi def link helpHeadlineValue helpHeadline

--- a/syntax/help_ja.vim
+++ b/syntax/help_ja.vim
@@ -8,3 +8,10 @@ syn region helpTransNote start="{訳注:" end="}" contains=helpLeadBlank,helpHyp
 syn region helpBracesInTransNote start=".{"ms=e end="}."me=s transparent contained contains=helpLeadBlank,helpHyperTextJump,helpBracesInTransNote
 syn match helpSpecial "[。、]\zs\[[-a-z^A-Z0-9_]\{2,}]"
 hi def link helpTransNote Special
+if has("conceal")
+  syn region helpHeadlineQuote matchgroup=helpIgnore start="^=" end="=$" contains=helpHeadlineValue keepend concealends
+else
+  syn region helpHeadlineQuote matchgroup=helpIgnore start="^=" end="=$" contains=helpHeadlineValue keepend
+endif
+syn match  helpHeadlineValue "[^=].\+[^=]" contained
+hi def link helpHeadlineValue helpHeadline

--- a/syntax/help_ja.vim
+++ b/syntax/help_ja.vim
@@ -9,9 +9,7 @@ syn region helpBracesInTransNote start=".{"ms=e end="}."me=s transparent contain
 syn match helpSpecial "[。、]\zs\[[-a-z^A-Z0-9_]\{2,}]"
 hi def link helpTransNote Special
 if has("conceal")
-  syn region helpHeadlineQuote matchgroup=helpIgnore start="^※\(\s\)\@!" end="\ze\(\s\+\*\|$\)" contains=helpHeadlineValue keepend concealends
+  syn region helpHeadline matchgroup=helpIgnore start="^※\(\s\)\@!" end="\ze\(\s\+\*\|$\)" keepend concealends
 else
-  syn region helpHeadlineQuote matchgroup=helpIgnore start="^※\(\s\)\@!" end="\ze\(\s\+\*\|$\)" contains=helpHeadlineValue keepend
+  syn region helpHeadline matchgroup=helpIgnore start="^※\(\s\)\@!" end="\ze\(\s\+\*\|$\)" keepend
 endif
-syn match  helpHeadlineValue "[^\s]*" contained
-hi def link helpHeadlineValue helpHeadline

--- a/syntax/help_ja.vim
+++ b/syntax/help_ja.vim
@@ -9,7 +9,7 @@ syn region helpBracesInTransNote start=".{"ms=e end="}."me=s transparent contain
 syn match helpSpecial "[。、]\zs\[[-a-z^A-Z0-9_]\{2,}]"
 hi def link helpTransNote Special
 if has("conceal")
-  syn region helpHeadline matchgroup=helpIgnore start="^※\(\s\)\@!" end="\ze\(\s\+\*\|$\)" keepend concealends
+  syn region helpHeadline matchgroup=helpIgnore start="^☆\(\s\)\@!" end="\ze\(\s\+\*\|$\)" keepend concealends
 else
-  syn region helpHeadline matchgroup=helpIgnore start="^※\(\s\)\@!" end="\ze\(\s\+\*\|$\)" keepend
+  syn region helpHeadline matchgroup=helpIgnore start="^☆\(\s\)\@!" end="\ze\(\s\+\*\|$\)" keepend
 endif

--- a/syntax/help_ja.vim
+++ b/syntax/help_ja.vim
@@ -9,9 +9,9 @@ syn region helpBracesInTransNote start=".{"ms=e end="}."me=s transparent contain
 syn match helpSpecial "[。、]\zs\[[-a-z^A-Z0-9_]\{2,}]"
 hi def link helpTransNote Special
 if has("conceal")
-  syn region helpHeadlineQuote matchgroup=helpIgnore start="^=" end="=$" contains=helpHeadlineValue keepend concealends
+  syn region helpHeadlineQuote matchgroup=helpIgnore start="^※\(\s\)\@!" end="\ze\(\s\+\*\|$\)" contains=helpHeadlineValue keepend concealends
 else
-  syn region helpHeadlineQuote matchgroup=helpIgnore start="^=" end="=$" contains=helpHeadlineValue keepend
+  syn region helpHeadlineQuote matchgroup=helpIgnore start="^※\(\s\)\@!" end="\ze\(\s\+\*\|$\)" contains=helpHeadlineValue keepend
 endif
-syn match  helpHeadlineValue "[^=].*[^=]" contained
+syn match  helpHeadlineValue "[^\s]*" contained
 hi def link helpHeadlineValue helpHeadline


### PR DESCRIPTION
小見出しに相当する helpHeadline 要素は英語向き定義になっている(行頭からすべて大文字がマッチ)。
例:

```text
MATHEMATICS
```

これが日本語では単純に再定義しようにも大文字小文字の区別がないため、設定できない(機能なし状態)。
そのため、見出し記法(直後の行に `---` を入れる)が利用されている。

これの改善を検討
ref https://github.com/vim-jp/vimdoc-ja-working/pull/1118#discussion_r956495439

結果として以下の構造を持つ syntax を定義するのを提案する。

<details>
  <summary>以前の提案</summary>
- 行頭の `=`
- 行末の `=`
- その中の `=` から開始も終了しない文字列 ( `===` といった helpSectionDelim に誤ってマッチしないように)
  現状最小2文字

リンクにある提案との差: 記号

- `●` を記号として定義されていたが、IMEやフォントの都合、複数の黒丸のどれが適切か判別が難しいこと
- 全角/半角などの要素を持ち込むので、なにかあると面倒になるかもしれない(推測)
- `=`  くくりは Wiki 系の一部記法での利用例があること
- conceal 方法を検討した結果 region の start / end がよさそう
  - end側について: くくるような記述であれば、記述上の把握もしやすく、覚えやすいのではないかとして、endにも記号ありで両方に記入しやすい記号を検討した

ただし、この記号は変更は容易なので、レビュー結果で変化しうる。

![](https://i.gyazo.com/eb761787a113fea604b10b12502eaca2.png)

- 上が編集中helpファイル(conceal解除状態)
- 下がhelp表示(concealされている状態)
</details>

- 行頭の `※`
- 記号直後に空白が含まれる場合はハイライトしない(日本語としては問題ないはず)
	- 単独の `※` でハイライトしないことを実現
- リンクが付いても問題なく

リンクにある提案との差: 記号

- k-takata さん提案の `※`
- conceal 方法を検討した結果 region の start / end がよさそう

まだちょっと悩む点

- region内の要素が受け付けるpattern: 現在は空白以外、としている

![](https://i.gyazo.com/fdb8e60f0f924f92b43acc179859c093.png)

- 上が編集中helpファイル(conceal解除状態、カラースキーム的に見えにくいですが、表示あり)
- 下がhelp表示(concealされている状態)

![](https://i.gyazo.com/6d632611dffc9e5ca2c06c5dfa4a6c06.png)

- digraph の `※`