### PR TITLE
switch to gtag.js for Google Analytics

### DIFF
--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,10 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-85527418-4"></script>
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-  ga('create', 'UA-85527418-4', 'auto');
-  ga('send', 'pageview');
-
+  gtag('config', 'UA-85527418-4');
 </script>


### PR DESCRIPTION
Google Analyticsの記述方法が古くなっていたために、新しい (といっても結構経ってる) gtag.js へ切り替えます。

ただ誰も見てない Google Analytics を残しておくのもアレなので、廃止の議論を別途やります。